### PR TITLE
Change solidity nix

### DIFF
--- a/nix/solidity-package.nix
+++ b/nix/solidity-package.nix
@@ -4,13 +4,14 @@
       (builtins.map
         (x: {
           "${x.name}/" = "${x}/dapp/${x.name}/src/";
+          "${x.name}" = "${x}/dapp/${x.name}/src/index.sol";
          } // x.remappings)
          xs);
   libPaths = xs:
     builtins.foldl' pkgs.lib.mergeAttrs {}
       (builtins.map
         (x: {
-          "${x.name}" = "${x}/dapp/${x.name}/src";
+          "${x.name}" = "${x}/dapp/${x.name}";
          } // x.libPaths)
          xs);
 in
@@ -24,8 +25,9 @@ in
     , ...
     } @ attrs:
       pkgs.stdenv.mkDerivation (rec {
-        inherit doCheck;
-        buildInputs = [ test-hevm solc ];
+        inherit doCheck extract;
+        buildInputs = [ solc pkgs.jq ]
+          ++ (pkgs.lib.optional (test-hevm != null) test-hevm);
         passthru = {
           remappings = remappings deps;
           libPaths = libPaths deps;


### PR DESCRIPTION
This looks to work with `dss-deploy-scripts`.

I think we should exclude `*.t.sol` files but that breaks `dss-deploys-scripts` because we are relying on transitive dependencies from the tests there it looks like. So this will work for now but would like to fix some things to make it more correct but also needs fixes in `dss-deploy-scripts`.